### PR TITLE
Reworked the logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,13 @@ Show pdf text contents
 
 ## Environment variables
 
-| Name         | Value                                                                          |
-|--------------|--------------------------------------------------------------------------------|
-| LOG_FILENAME | file to log in. Default value : `log/app.log`                                  |
-| LOG_LEVEL    | one of `debug`, `info`, `warn`, `error`, `panic` or `fatal`. Default is `info` |
+| Name              | Value                                                                                     |
+|-------------------|-------------------------------------------------------------------------------------------|
+| LOG_TXT_FILENAME  | file to log in, in plain text. Possible values: `stdout`, `stderr`, any filename.         |
+| LOG_JSON_FILENAME | file to log in, in json format. Possible values: `stdout`, `stderr`, any filename.        |
+| LOG_LEVEL         | one of `debug`, `info`, `warn`, `error`, `panic` or `fatal`. Default is `info`            |
+
+Note : if none of `LOG_TXT_FILENAME` or `LOG_JSON_FILENAME` is set, logging will output to stdout in plain text format, same as if `LOG_TXT_FILENAME=stdout`.
 
 ## Licensing
 

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -47,7 +47,8 @@ func TestFromTemplateWithCommonTemplate(t *testing.T) {
 }
 
 func TestFromTemplateWithBrokenTemplate(t *testing.T) {
-	os.Setenv("LOG_FILENAME", logFilename)
+	os.Setenv("LOG_JSON_FILENAME", logFilename)
+	defer os.Unsetenv("LOG_JSON_FILENAME")
 	defer os.Remove(logFilename)
 	o := New("year {{ .year }}", months)
 


### PR DESCRIPTION
Rework of the logger

- the logger is now created in a specific function (instead of anonymous function). This lets cover more tests (with json and plaintext)
- the environment variables `LOG_FILENAME` was replaced with `LOG_JSON_FILENAME` and a new `LOG_TXT_FILENAME` appears for more flexibility. See README.md for how to use them.
