### PR TITLE
docs: add latest version badge and codecov upload to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,5 +32,12 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Test
-        run: go test -v ./...
+      - name: Test with coverage
+        run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ![Lint Status](https://github.com/ymettier/fileganizer/workflows/golangci-lint/badge.svg)
 ![Build Status](https://github.com/ymettier/fileganizer/workflows/go-build/badge.svg)
+![Latest Version](https://img.shields.io/github/v/release/ymettier/fileganizer)
 
 # Fileganizer
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 /* Copyright 2023-2026 The Fileganizer Authors. All rights reserved. */
 /* SPDX-License-Identifier: MIT */
 
-![Lint Status](https://github.com/ymettier/fileganizer/workflows/golangci-lint/badge.svg)
-![Build Status](https://github.com/ymettier/fileganizer/workflows/go-build/badge.svg)
-![Latest Version](https://img.shields.io/github/v/release/ymettier/fileganizer)
+[![github](https://img.shields.io/badge/github-ymettier/fileganizer-181717?logo=github)](https://github.com/ymettier/fileganizer)
+[![version](https://img.shields.io/github/v/release/ymettier/fileganizer?color=blue)](https://github.com/ymettier/fileganizer/releases)
+[![license](https://img.shields.io/github/license/ymettier/fileganizer?color=blue)](https://github.com/ymettier/fileganizer/blob/main/LICENSE)
+[![go](https://github.com/ymettier/fileganizer/actions/workflows/go/badge.svg)](https://github.com/ymettier/fileganizer/actions/workflows/go.yml)
+[![golangci-lint](https://github.com/ymettier/fileganizer/actions/workflows/golangci-lint/badge.svg)](https://github.com/ymettier/fileganizer/actions/workflows/golangci-lint.yml)
+[![codecov](https://codecov.io/gh/ymettier/fileganizer/branch/main/graph/badge.svg)](https://codecov.io/gh/ymettier/fileganizer)
 
 # Fileganizer
 


### PR DESCRIPTION
- Add GitHub release badge (stable version) and codecov badge to README
- Add codecov upload step to go.yml with coverage.out, codecov/codecov-action@v7, and CODECOV_TOKEN secret
