### PR TITLE
docs: move README copyright to end of file and document the convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Fileganizer is a Go CLI tool that processes documents through a pipeline: text e
   ```
 - Copyright year is always 2023-XXXX (project founding year to the present)
 - All source file should have a copyright header (the syntax depends on the file type). For non-go files, use the appropriate comment syntax (e.g., `//` for `.txt`, `/*` for `.md`) and set a header similar to the `.go` files.
+- Copyright for README.md file must be set at the end of the file.
 - All public functions should have documentation comments
 - Keep functions focused and under 50 lines when possible
 - Use meaningful variable names

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-/* Copyright 2023-2026 The Fileganizer Authors. All rights reserved. */
-/* SPDX-License-Identifier: MIT */
-
 [![github](https://img.shields.io/badge/github-ymettier/fileganizer-181717?logo=github)](https://github.com/ymettier/fileganizer)
 [![version](https://img.shields.io/github/v/release/ymettier/fileganizer?color=blue)](https://github.com/ymettier/fileganizer/releases)
 [![license](https://img.shields.io/github/license/ymettier/fileganizer?color=blue)](https://github.com/ymettier/fileganizer/blob/main/LICENSE)
@@ -90,3 +87,6 @@ The key is lowercased and dots replaced with underscores. Examples:
 ## Licensing
 
 This project is licensed under the MIT License. See the LICENSE file for the full license text.
+
+/* Copyright 2023-2026 The Fileganizer Authors. All rights reserved. */
+/* SPDX-License-Identifier: MIT */


### PR DESCRIPTION
- Add rule to AGENTS.md: README.md copyright must be at end of file
- Move copyright header from top of README.md to after the Licensing section