### PR TITLE
refactor: replace map[string]any template data with typed TemplateData struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,10 +130,10 @@ func processFileDescriptions(ctx context.Context, cfg *config.Config, txt string
 		if r == nil {
 			continue
 		}
-		values := map[string]any{
-			"Env":      cfg.EnvVars,
-			"Grok":     r,
-			"Filename": cfg.InputFile,
+		values := output.TemplateData{
+			Env:      cfg.EnvVars,
+			Grok:     r,
+			Filename: cfg.InputFile,
 		}
 		outputResult, err := o.FromTemplate(fd.Output, values)
 		if err != nil {

--- a/output/output.go
+++ b/output/output.go
@@ -13,6 +13,15 @@ import (
 	"fileganizer/logger"
 )
 
+// TemplateData holds the values available to Go templates during rendering.
+// Fields are exported (capitalized) so text/template can access them via
+// reflection. Map keys within Grok and Env remain lowercase.
+type TemplateData struct {
+	Env      map[string]string
+	Grok     map[string]string
+	Filename string
+}
+
 // Output holds template configuration and renders Go templates with parsed data.
 type Output struct {
 	commonTemplate string
@@ -42,8 +51,8 @@ func (o Output) MonthIndex(month string) string {
 }
 
 // FromTemplate renders the output template (prefixed with CommonTemplate if set)
-// using the provided variables and returns the result as a string.
-func (o Output) FromTemplate(tmpl string, vars map[string]any) (string, error) {
+// using the provided TemplateData and returns the result as a string.
+func (o Output) FromTemplate(tmpl string, data TemplateData) (string, error) {
 	l := logger.Get()
 	funcMap := template.FuncMap{
 		"ToUpper":            strings.ToUpper,
@@ -65,7 +74,7 @@ func (o Output) FromTemplate(tmpl string, vars map[string]any) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := parsed.Execute(&buf, vars); err != nil {
+	if err := parsed.Execute(&buf, data); err != nil {
 		l.Error("Failed to execute template", "error", err)
 		return "", err
 	}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -13,40 +13,42 @@ var months = map[string][]string{
 	"French": {"Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Aout", "Septembre", "Octobre", "Novembre", "Décembre"},
 }
 
-var vars = map[string]any{
-	"year":       "1970",
-	"identifier": "123",
+var testVars = TemplateData{
+	Grok: map[string]string{
+		"year":       "1970",
+		"identifier": "123",
+	},
 }
 
 var templates = map[string]string{
-	"year 1970 identifier 123": `year {{ .year }} identifier {{ .identifier }}`,
-	"year 1970 lowercase":      `year {{ .year }} {{ ToLower "LoWerCaSe" }}`,
-	"year 1970 UPPERCASE":      `year {{ .year }} {{ ToUpper "UppErCaSe" }}`,
-	"year 1970 month 03":       `year {{ .year }} month {{ MonthIndex "Mars" }}`,
+	"year 1970 identifier 123": `year {{ .Grok.year }} identifier {{ .Grok.identifier }}`,
+	"year 1970 lowercase":      `year {{ .Grok.year }} {{ ToLower "LoWerCaSe" }}`,
+	"year 1970 UPPERCASE":      `year {{ .Grok.year }} {{ ToUpper "UppErCaSe" }}`,
+	"year 1970 month 03":       `year {{ .Grok.year }} month {{ MonthIndex "Mars" }}`,
 }
 
 func TestFromTemplate(t *testing.T) {
 	for wants, tpl := range templates {
 		o := New(tpl, months)
 
-		r, err := o.FromTemplate("", vars)
+		r, err := o.FromTemplate("", testVars)
 		assert.NoErrorf(t, err, "Fails on template '%s'", tpl)
 		assert.Equalf(t, wants+"\n", r, "Fails on template '%s'", tpl)
 	}
 }
 
 func TestFromTemplateWithCommonTemplate(t *testing.T) {
-	o := New("year {{ .year }}", months)
+	o := New("year {{ .Grok.year }}", months)
 
-	r, err := o.FromTemplate("{{ .identifier }}", vars)
+	r, err := o.FromTemplate("{{ .Grok.identifier }}", testVars)
 	assert.NoError(t, err)
 	assert.Equal(t, "year 1970\n123", r)
 }
 
 func TestFromTemplateWithBrokenTemplate(t *testing.T) {
-	o := New("year {{ .year }}", months)
+	o := New("year {{ .Grok.year }}", months)
 
-	_, err := o.FromTemplate("{{", vars)
+	_, err := o.FromTemplate("{{", testVars)
 	assert.Error(t, err)
 }
 
@@ -54,14 +56,14 @@ func TestFromTemplate_ExecuteError(t *testing.T) {
 	o := New("", nil)
 
 	// ToUpper expects a string; passing an int causes a type error at execution
-	_, err := o.FromTemplate("{{ ToUpper 42 }}", nil)
+	_, err := o.FromTemplate("{{ ToUpper 42 }}", TemplateData{})
 	assert.Error(t, err)
 }
 
 func TestFromTemplate_NowFunctions(t *testing.T) {
 	o := New("{{ NowYYYY }}-{{ NowYYYYMMDD }}-{{ NowYYYYMMDD_HHMMSS }}", nil)
 
-	r, err := o.FromTemplate("", nil)
+	r, err := o.FromTemplate("", TemplateData{})
 	assert.NoError(t, err)
 	assert.Regexp(t, `^\d{4}-\d{8}-\d{8}_\d{6}\n$`, r)
 }


### PR DESCRIPTION
Replace map[string]any with a typed TemplateData struct for better type safety.
Template keys are now PascalCase (.Env, .Grok, .Filename).

Changes:
- output/: add TemplateData struct with Env, Grok, Filename fields
- output/: update FromTemplate signature to accept TemplateData
- main.go: use output.TemplateData instead of map[string]any
