### PR TITLE
docs: update AGENTS.md, README.md, and fix testutil copyright year

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@ Fileganizer is a Go CLI tool that processes documents through a pipeline: text e
 - **Logging**: `log/slog` (stdlib, text handler, defaults to stderr)
 - **Log rotation**: `gopkg.in/natefinch/lumberjack.v2`
 - **Templates**: `text/template` (stdlib)
+- **PDF extraction**: `github.com/pdfcpu/pdfcpu`
 - **Testing**: `testing` + `github.com/stretchr/testify/assert`
-- **Build**: GoReleaser, CGO_ENABLED=0, Linux only (amd64/arm64)
+- **Build**: GoReleaser (`.goreleaser.yaml`), CGO_ENABLED=0, Linux only (amd64/arm64)
 - Avoid `github.com/sirupsen/logrus` (blocked by depguard linter)
 
 ## Project Structure
@@ -32,21 +33,29 @@ Fileganizer is a Go CLI tool that processes documents through a pipeline: text e
 ├── logger/
 │   ├── logger.go          # Structured logging (slog singleton)
 │   └── logger_test.go
+├── pdftotext/
+│   ├── pdftotext.go       # Builtin PDF text extraction (pdfcpu)
+│   ├── pdftotext_test.go
+│   └── testdata/          # PDF test fixtures (forged + bank statements)
 ├── textextract/
 │   ├── textextract.go     # External command text extraction
 │   └── textextract_test.go
 ├── testutil/
 │   ├── testutil.go        # Test helpers (temp dir, etc.)
 │   └── testutil_test.go
-├── testdata/              # Test fixtures (PDF, text, config YAMLs)
+├── testdata/              # Config YAMLs, text fixtures, minimal.wav
 ├── config.yaml.sample     # Example configuration
+├── go.mod                 # Go module definition
+├── go.sum                 # Go module checksums
+├── LICENSE                # License (also mandatory in testdata subdirectories)
+├── README.md
 └── version.txt            # Embedded at build time (//go:embed)
 ```
 
 ## Development Guidelines
 
 ### Code Style
-- Use structured logging (slog) instead of fmt.Printf for application output
+- Use structured logging (slog) instead of fmt.Printf for application output. The exception is `main()` in `main.go` which may use `fmt.Print`/`fmt.Printf`/`fmt.Fprintf` directly for CLI output (result to stdout, version to stdout, error message to stderr). Never use it in any other function.
 - All public functions should have documentation comments
 - Keep functions focused and under 50 lines when possible
 - Use meaningful variable names
@@ -72,6 +81,7 @@ Fileganizer is a Go CLI tool that processes documents through a pipeline: text e
 - Constructors: `New()` returns a value (not pointer) for small structs.
 - Logger: singleton via `logger.Get()`.
 - Context: pass `context.Context` to operations that may need cancellation.
+- Grok patterns are compiled fresh on every `Parse()` call. Each pattern is only used a few times (once per file per fileDescription), so caching adds complexity for no measurable gain.
 
 ### Configuration Management
 - Use Koanf for all YAML parsing
@@ -108,8 +118,15 @@ Fileganizer is a Go CLI tool that processes documents through a pipeline: text e
 - Use testify assertions (`assert.Equal`, `assert.Nil`, `assert.FileExists`)
 - Tests should be isolated and use temporary files/directories
 - Always clean up test artifacts with defer
-- Test data files must be placed in the `testdata/` directory
+- Test data files go in the package-local `testdata/` directory (e.g., `pdftotext/testdata/` for PDFs, root `testdata/` for config YAMLs)
+- A `LICENSE` file (MIT) is mandatory in `testdata/` directories containing files from external sources — it is not test data and is excluded from the unused file check
+- Config files in `testdata/` testing invalid/broken patterns must be named `config.broken.<what>.yaml` (e.g., `config.broken.grok.yaml`, `config.broken.template.yaml`)
+- `config.broken.mime.yaml` tests the "no extractor for MIME type" error path — `audio/wave` is deliberately unsupported and will never have a builtin extractor added
 - Unused testdata files must be removed
+- **Coverage requirements**:
+  - All packages: 100% statement coverage
+  - Exception: `testutil/` minimum 70% (error branches for unreachable system calls)
+  - Exception: `main` (root package) minimum 90% (end-to-end tests)
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Fileganizer is a tool that will
 - parse the extracted text with grok-like patterns,
 - choose a pre-configured go-template depending on parsing results,
 - generate a result with go-template,
-- optionaly run the result (as a command).o
+- optionally run the result (as a command).
 
 The use-case is to run some pdftotext command to extract text from your invoices and other similar documents, try to find patterns like IDs, date, name, and rename (move) the file using the results of the parsing.
 
@@ -21,7 +21,7 @@ The use-case is to run some pdftotext command to extract text from your invoices
 
 Copy `config.yaml.sample` as `config.yaml`. Edit the file:
 
-Leave `ExtractTextCommand` as is if you have `pdftotext` installed. Or change it if you prefer using another tool.
+Leave `textExtractor` as is. PDF files are extracted with the built-in parser. If you prefer using an external tool like `pdftotext`, change the `type` to `command` and set the `command` accordingly.
 
 Leave `env` as is or declare other environment variables according to your needs. These environment variables will be available in your go-templates.
 
@@ -33,10 +33,10 @@ Leave `grokPatterns` as is. You may add new patterns later, according to your ne
 
 Now we will work with `fileDescriptions` that contains `patterns` to try to apply on the input file and `output` as a go-template that we configure as a shell command.
 
-1. Run `fileganizer -c config.yaml -f yourfile.pdf -t`. This will print the output of the `ExtractTextCommand`.
+1. Run `fileganizer -c config.yaml -f yourfile.pdf -t`. This will print the output of the `textExtractor`.
 2. identify some interesting patterns, for example a date, an identifier...
 3. add these patterns with grok syntax (learn with [Grok filter plugin from Logstash](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html)). Note that the parser is [Grokky](https://github.com/logrusorgru/grokky) and is not fully compatible with Grok.
-4. forge a go-template output with all avaiable variables (`.filename`, `.env.XXX` for environment variables, `.grok.xxx` for parsed data.
+4. forge a go-template output with all available variables (`.Filename`, `.Env.XXX` for environment variables, `.Grok.xxx` for parsed data).
 5. Run `fileganizer -c config.yaml -f yourfile.pdf` (without the `-t` option). This do all the job and print the generated result.
 
 You can iterate as many times as you need to improve the template. You can also add other `fileDescriptions` to identify other document types and print from other go-templates.

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2026 The Fileganizer Authors. All rights reserved.
+// Copyright 2026 The Fileganizer Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 package testutil


### PR DESCRIPTION
- AGENTS.md: add pdfcpu to tech stack, pdftotext to project tree,
  coverage requirements, testdata naming conventions, grok caching
  decision, and clarify fmt.Printf exception for main.go CLI output
- README.md: fix typo (optionaly → optionally), update textExtractor
  config instructions, capitalize template variables (.Filename, .Env,
  .Grok)
- testutil/testutil.go: fix copyright year (2023-2026 → 2026, file
  was created in 2026)
