### PR TITLE
feat: log warning for invalid octal escape values exceeding byte range

### DIFF
--- a/pdftotext/pdftotext.go
+++ b/pdftotext/pdftotext.go
@@ -221,6 +221,8 @@ func writeEscaped(b *strings.Builder, s string, i int) int {
 			v, _ := strconv.ParseUint(oct, 8, 32)
 			if v <= maxByte {
 				b.WriteByte(byte(v))
+			} else {
+				logger.Get().Warn("invalid octal escape in PDF literal string, value exceeds byte range", "value", v, "octal", oct)
 			}
 		} else {
 			b.WriteByte(s[i])

--- a/pdftotext/pdftotext_test.go
+++ b/pdftotext/pdftotext_test.go
@@ -252,6 +252,10 @@ func TestParseLiteralString_EdgeCases(t *testing.T) {
 		assert.Equal(t, "\377", parseLiteralString("(\\377)"))
 	})
 
+	t.Run("octal escape overflow", func(t *testing.T) {
+		assert.Equal(t, "", parseLiteralString("(\\777)"))
+	})
+
 	t.Run("default escape", func(t *testing.T) {
 		assert.Equal(t, "x", parseLiteralString("(\\x)"))
 	})


### PR DESCRIPTION
When a PDF literal string contains an octal escape sequence whose value
exceeds 255 (e.g. \777 = 511), the byte is silently dropped. This
indicates a malformed or corrupted PDF.

Add a Warn-level log message in writeEscaped that reports the offending
value and octal string, so users can identify problematic PDFs during
text extraction.

Also adds a test case (octal_escape_overflow) to maintain 100%
statement coverage.
